### PR TITLE
修复BING翻译缺失REGION参数的问题

### DIFF
--- a/nonebot_plugin_novelai/config.py
+++ b/nonebot_plugin_novelai/config.py
@@ -55,7 +55,8 @@ class Config(BaseSettings):
     """是否自动撤回，该值不为0时，则为撤回时间"""
 
     bing_key: str = None
-    """bing的翻译key"""
+    bing_region: str = None
+    """bing的翻译key和region"""
     deepl_key: str = None
     """deepL的翻译key"""
 

--- a/nonebot_plugin_novelai/utils/translation.py
+++ b/nonebot_plugin_novelai/utils/translation.py
@@ -28,8 +28,12 @@ async def translate_bing(text: str, to: str):
     key = config.bing_key
     if not key:
         return None
+    region = config.bing_region
+    if not region:
+        return None
     header = {
         "Ocp-Apim-Subscription-Key": key,
+        "Ocp-Apim-Subscription-Region": region,
         "Content-Type": "application/json",
     }
     async with aiohttp.ClientSession() as session:


### PR DESCRIPTION
目前bing翻译会返回
```
{"error":{"code":401000,"message":"The request is not authorized because credentials are missing or invalid."}}
```

经过测试，必须在header中传递 `Ocp-Apim-Subscription-Region`

参考官方Example [Text-Translation-API-V3-Python/Translate.py](https://github.com/MicrosoftTranslator/Text-Translation-API-V3-Python)